### PR TITLE
[Vindex] Added Output Log to commit to map state

### DIFF
--- a/vindex/README.md
+++ b/vindex/README.md
@@ -191,7 +191,7 @@ In this repository, there is a demo of running a [tlog-tiles][] log using [Tesse
 Below are instructions for running this demo with sample key material:
 
 ```shell
-LOG_PRIVATE_KEY=PRIVATE+KEY+logandmap+38581672+AXJ0FKWOcO2ch6WC8kP705Ed3Gxu7pVtZLhfHAQwp+FE; go run ./vindex/cmd/logandmap --input_log_dir ~/logandmap/inputlog/ --walPath ~/logandmap/map.wal
+INPUT_LOG_PRIVATE_KEY=PRIVATE+KEY+example.com/inputlog+bd6268fb+ATPZW5UsUYHJo24lwgK1ykm9VafhyUtUxX5evV4ZIokY OUTPUT_LOG_PRIVATE_KEY=PRIVATE+KEY+example.com/outputlog+07392c46+ATPJ4crkyUbPeaRffN/4NUof3KV0pQznVIPGOQm3SDEJ go run ./vindex/cmd/logandmap --storage_dir ~/logandmap/
 ```
 
 Running the above will run a web server hosting the following URLs:
@@ -203,7 +203,11 @@ The input log has entries for packages in the set {`foo`, `bar`, `baz`, `splat`}
 To inspect the log, you can use the woodpecker tool (using the corresponding public key to the private key used above):
 
 ```shell
-go run github.com/mhutchinson/woodpecker@main --custom_log_type=tiles --custom_log_url=http://localhost:8088/inputlog --custom_log_vkey=logandmap+38581672+Ab/PCr1eCclRPRMBqw/r5An1xO71MCnImLiospEq6b4l
+# To inspect the Input Log
+go run github.com/mhutchinson/woodpecker@main --custom_log_type=tiles --custom_log_url=http://localhost:8088/inputlog/ --custom_log_vkey=example.com/inputlog+bd6268fb+AWdGkrHKBm+pOubTrcBTV8JMDLFlF1Y8WUH1nrtLNXDr
+
+# To inspect the Output Log
+go run github.com/mhutchinson/woodpecker@main --custom_log_type=tiles --custom_log_url=http://localhost:8088/outputlog/ --custom_log_vkey=example.com/outputlog+07392c46+AWyS8y8ZsRmQnTr6Fr2knaa8+t6CPYFh5Ho3wJEr14B8
 ```
 
 Use left/right cursor to browse, and `q` to quit.
@@ -222,7 +226,7 @@ go run ./vindex/cmd/client --base_url http://localhost:8088/vindex/ --lookup=foo
 |  2  | Implementation of in-memory Merkle Radix Tree             |   ✅   |
 |  3  | Incremental update                                        |   ✅   |
 |  4  | Verify that mapped data matches Input Log Checkpoint      |   ✅   |
-|  5  | Output log                                                |   ❌   |
+|  5  | Output log                                                |   ✅   |
 |  6  | Proofs served on Lookup                                   |   ❌   |
 |  7  | Storage backed verifiable-map                             |   ❌   |
 |  8  | MapFn defined in WASM                                     |   ❌   |

--- a/vindex/outputlog.go
+++ b/vindex/outputlog.go
@@ -1,0 +1,75 @@
+// Copyright 2025 Google LLC. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package vindex
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/transparency-dev/formats/log"
+	"github.com/transparency-dev/tessera"
+	"github.com/transparency-dev/tessera/storage/posix"
+	"golang.org/x/mod/sumdb/note"
+)
+
+// outputLogOrDie returns an output log using a POSIX log in the given directory.
+func NewOutputLog(ctx context.Context, outputLogDir string, s note.Signer, v note.Verifier) (log OutputLog, closer func(), err error) {
+	driver, err := posix.New(ctx, posix.Config{Path: outputLogDir})
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to create input log: %v", err)
+	}
+
+	appender, shutdown, reader, err := tessera.NewAppender(ctx, driver, tessera.NewAppendOptions().
+		WithCheckpointSigner(s).
+		WithCheckpointInterval(5*time.Second).
+		WithBatching(1, time.Second))
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to get appender: %v", err)
+	}
+	awaiter := tessera.NewPublicationAwaiter(ctx, reader.ReadCheckpoint, 100*time.Millisecond)
+
+	outputLog := posixOutputLog{
+		a: appender,
+		w: awaiter,
+		r: reader,
+		v: v,
+	}
+
+	return outputLog, func() {
+		_ = shutdown(ctx)
+	}, nil
+}
+
+type posixOutputLog struct {
+	a *tessera.Appender
+	w *tessera.PublicationAwaiter
+	r tessera.LogReader
+	v note.Verifier
+}
+
+func (l posixOutputLog) Checkpoint(ctx context.Context) (checkpoint []byte, err error) {
+	return l.r.ReadCheckpoint(ctx)
+}
+
+func (l posixOutputLog) Parse(cpRaw []byte) (*log.Checkpoint, error) {
+	cp, _, _, err := log.ParseCheckpoint(cpRaw, l.v.Name(), l.v)
+	return cp, err
+}
+
+func (l posixOutputLog) Append(ctx context.Context, data []byte) (idx uint64, checkpoint []byte, err error) {
+	index, cp, err := l.w.Await(ctx, l.a.Add(ctx, tessera.NewEntry(data)))
+	return index.Index, cp, err
+}


### PR DESCRIPTION
The Output Log is a POSIX Tessera log in the provided demo, but can be
changed for any other implementation that matches the OutputLog
interface.

The OutputLog is updated any time the vindex is updated. The value
written to the new leaf is the concatenation of:
 1. hex encoding of the map root
 2. a couple of newline characters
 3. the raw checkpoint from the InputLog at which the vindex was built

This includes a refactoring to push the checkpoint parsing into the
Input and Output Log definitions to improve encapsulation.

This unlocks what we need to start generating fully comprehensive proofs
for Lookup operations.
