### PR TITLE
Lookup returns mostly provable response

### DIFF
--- a/vindex/api/api.go
+++ b/vindex/api/api.go
@@ -44,7 +44,6 @@ type LookupResponse struct {
 	// These values represent the lookup operation in the index at the root hash
 	// committed to by OutputLogLeaf. The values contain all indices for the given
 	// key, and the proof binds these values at this key at the index root hash.
-	IndexKey   [sha256.Size]byte   `json:"index_key"`
 	IndexValue []uint64            `json:"index_value"`
 	IndexProof [][sha256.Size]byte `json:"index_proof"`
 }

--- a/vindex/cmd/client/client.go
+++ b/vindex/cmd/client/client.go
@@ -65,7 +65,7 @@ func run(ctx context.Context) error {
 		return fmt.Errorf("failed to look up key: %v", err)
 	}
 
-	fmt.Printf("Indices: %v", idxes)
+	fmt.Printf("Indices: %v\n", idxes)
 
 	return nil
 }
@@ -114,12 +114,12 @@ func (c VIndexClient) Lookup(ctx context.Context, key string) ([]uint64, error) 
 		return nil, fmt.Errorf("failed to parse output log checkpoint: %v", err)
 	}
 	outLeafHash := rfc6962.DefaultHasher.HashLeaf(resp.OutputLogLeaf)
-	old := make([][]byte, len(resp.OutputLogProof))
-	for i := range old {
-		old[i] = resp.OutputLogProof[i][:]
+	olp := make([][]byte, len(resp.OutputLogProof))
+	for i := range olp {
+		olp[i] = resp.OutputLogProof[i][:]
 	}
 	oli := cp.Size - 1 // TODO(mhutchinson): include this in the response?
-	if err := proof.VerifyInclusion(rfc6962.DefaultHasher, oli, cp.Size, outLeafHash[:], old, cp.Hash); err != nil {
+	if err := proof.VerifyInclusion(rfc6962.DefaultHasher, oli, cp.Size, outLeafHash[:], olp, cp.Hash); err != nil {
 		return nil, fmt.Errorf("failed to verify inclusion in output log: %v", err)
 	}
 	var mapRoot []byte

--- a/vindex/cmd/logandmap/README.md
+++ b/vindex/cmd/logandmap/README.md
@@ -1,6 +1,6 @@
 ## Verifiable Index: Log & Map
 
-This is a demo of using a [Tessera][] Verifiable Log as the Input Log, with all entries indexed into a [Verifiable Index](../../README.md).
+This is a demo of using a [Tessera][] Verifiable Log as the Input Log, with all entries indexed by a [Verifiable Index](../../README.md).
 
 [tlog-tiles]: https://c2sp.org/tlog-tiles
 [Tessera]: https://github.com/transparency-dev/tessera
@@ -24,8 +24,8 @@ i.e. the key that is put into the map has the following value:
 
 ```go
 		sha256.Sum256([]byte(entry.Module))
-
 ```
+
 This allows the owner of a given module to look up the modules they are responsible for, and verifiably
 find the index of all entries in the Input Log for their modules.
 

--- a/vindex/cmd/logandmap/README.md
+++ b/vindex/cmd/logandmap/README.md
@@ -1,0 +1,62 @@
+## Verifiable Index: Log & Map
+
+This is a demo of using a [Tessera][] Verifiable Log as the Input Log, with all entries indexed into a [Verifiable Index](../../README.md).
+
+[tlog-tiles]: https://c2sp.org/tlog-tiles
+[Tessera]: https://github.com/transparency-dev/tessera
+
+The entries in the Input Log loosely represent Binary/Artifact Registry entries, committing to a triple of `{module name, module version, artifact hash}`:
+
+```
+{
+  "module": "bar",
+  "version": "2025-08-07T10:41:56.527888424Z",
+  "hash": "vsOru/9zZqrLjamAgzvQCaSvpMmF9jy+r75HpMvncZc="
+}
+```
+
+This pattern is very common: committing that a module at a given version has a particular hash.
+This hash could represent the git commit fingerprint the release was tagged from, the hash of a compiled binary, etc.
+See [Transparency.dev: Add tamper checking to a package manager](https://transparency.dev/application/add-tamper-checking-to-a-package-manager/) for more background on this pattern.
+
+This Input Log is processed, with each entry being indexed solely on the `module`,
+i.e. the key that is put into the map has the following value:
+
+```go
+		sha256.Sum256([]byte(entry.Module))
+
+```
+This allows the owner of a given module to look up the modules they are responsible for, and verifiably
+find the index of all entries in the Input Log for their modules.
+
+## Running
+
+The Input Log, Verifiable Index, and Output Log are all managed by a single binary:
+
+```shell
+INPUT_LOG_PRIVATE_KEY=PRIVATE+KEY+example.com/inputlog+bd6268fb+ATPZW5UsUYHJo24lwgK1ykm9VafhyUtUxX5evV4ZIokY OUTPUT_LOG_PRIVATE_KEY=PRIVATE+KEY+example.com/outputlog+07392c46+ATPJ4crkyUbPeaRffN/4NUof3KV0pQznVIPGOQm3SDEJ go run ./vindex/cmd/logandmap --storage_dir ~/logandmap/
+```
+
+Running the above will run a web server hosting the following URLs:
+ - `/inputlog/` - the [tlog-tiles][] base URL for the input log
+ - `/vindex/lookup` - the provisional [vindex lookup API](./api/api.go)
+ - `/outputlog/` - TODO(mhutchinson): this is where the output log will be hosted
+
+The input log has entries for packages in the set {`foo`, `bar`, `baz`, `splat`}.
+To inspect the log, you can use the woodpecker tool (using the corresponding public key to the private key used above):
+
+```shell
+# To inspect the Input Log
+go run github.com/mhutchinson/woodpecker@main --custom_log_type=tiles --custom_log_url=http://localhost:8088/inputlog/ --custom_log_vkey=example.com/inputlog+bd6268fb+AWdGkrHKBm+pOubTrcBTV8JMDLFlF1Y8WUH1nrtLNXDr
+
+# To inspect the Output Log
+go run github.com/mhutchinson/woodpecker@main --custom_log_type=tiles --custom_log_url=http://localhost:8088/outputlog/ --custom_log_vkey=example.com/outputlog+07392c46+AWyS8y8ZsRmQnTr6Fr2knaa8+t6CPYFh5Ho3wJEr14B8
+```
+
+Use left/right cursor to browse, and `q` to quit.
+
+This log is processed into a verifiable map which can be looked up using the following command:
+
+```shell
+go run ./vindex/cmd/client --base_url http://localhost:8088/vindex/ --out_log_pub_key=example.com/outputlog+07392c46+AWyS8y8ZsRmQnTr6Fr2knaa8+t6CPYFh5Ho3wJEr14B8 --lookup=foo
+```

--- a/vindex/cmd/logandmap/main.go
+++ b/vindex/cmd/logandmap/main.go
@@ -255,13 +255,7 @@ func submitEntries(ctx context.Context, appender *tessera.Appender) {
 }
 
 func runWebServer(vi *vindex.VerifiableIndex, inLogDir, outLogDir string) {
-	web := NewServer(func(h [sha256.Size]byte) ([]uint64, error) {
-		idxes, size := vi.Lookup(h)
-		if size == 0 {
-			return nil, errors.New("index not populated")
-		}
-		return idxes, nil
-	})
+	web := NewServer(vi.Lookup)
 
 	ilfs := http.FileServer(http.Dir(inLogDir))
 	olfs := http.FileServer(http.Dir(outLogDir))

--- a/vindex/map_test.go
+++ b/vindex/map_test.go
@@ -40,7 +40,7 @@ const (
 )
 
 func TestVerifiableIndex(t *testing.T) {
-	ctx := context.Background()
+	ctx := t.Context()
 	s, v, err := fnote.NewEd25519SignerVerifier(skey)
 	if err != nil {
 		t.Fatal(err)
@@ -91,28 +91,28 @@ func TestVerifiableIndex(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	idxes, size := vi.Lookup(sha256.Sum256([]byte("foo")))
-	if size != 4 {
-		t.Errorf("expected size 4 but got %d", size)
+	resp, err := vi.Lookup(t.Context(), sha256.Sum256([]byte("foo")))
+	if err != nil {
+		t.Fatal(err)
 	}
-	if want := []uint64{0, 3}; !cmp.Equal(idxes, want) {
-		t.Errorf("expected %v but got %v", want, idxes)
-	}
-
-	idxes, size = vi.Lookup(sha256.Sum256([]byte("bar")))
-	if size != 4 {
-		t.Errorf("expected size 4 but got %d", size)
-	}
-	if want := []uint64{1, 2}; !cmp.Equal(idxes, want) {
-		t.Errorf("expected %v but got %v", want, idxes)
+	if got, want := resp.IndexValue, []uint64{0, 3}; !cmp.Equal(got, want) {
+		t.Errorf("expected %v but got %v", want, got)
 	}
 
-	idxes, size = vi.Lookup(sha256.Sum256([]byte("banana")))
-	if size != 4 {
-		t.Errorf("expected size 4 but got %d", size)
+	resp, err = vi.Lookup(t.Context(), sha256.Sum256([]byte("bar")))
+	if err != nil {
+		t.Fatal(err)
 	}
-	if idxes != nil {
-		t.Errorf("expected no results but got %+v", idxes)
+	if got, want := resp.IndexValue, []uint64{1, 2}; !cmp.Equal(got, want) {
+		t.Errorf("expected %v but got %v", want, got)
+	}
+
+	resp, err = vi.Lookup(t.Context(), sha256.Sum256([]byte("banana")))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if resp.IndexValue != nil {
+		t.Errorf("expected no results but got %+v", resp.IndexValue)
 	}
 }
 

--- a/vindex/outputlog_test.go
+++ b/vindex/outputlog_test.go
@@ -1,0 +1,108 @@
+// Copyright 2025 Google LLC. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// vindex contains a prototype of an in-memory verifiable index.
+// This version uses the clone tool DB as the log source.
+package vindex
+
+import (
+	"os"
+	"testing"
+
+	fnote "github.com/transparency-dev/formats/note"
+	"github.com/transparency-dev/merkle/proof"
+	"github.com/transparency-dev/merkle/rfc6962"
+)
+
+func TestOutputLog_Lookup(t *testing.T) {
+	s, v, err := fnote.NewEd25519SignerVerifier(skey)
+	if err != nil {
+		t.Fatal(err)
+	}
+	testCases := []struct {
+		desc      string
+		leaves    []string
+		lookupIdx uint64
+		wantErr   bool
+	}{
+		{
+			desc:      "single entry log",
+			leaves:    []string{"foo"},
+			lookupIdx: 0,
+			wantErr:   false,
+		},
+		{
+			desc:      "two entry log",
+			leaves:    []string{"foo", "bar"},
+			lookupIdx: 1,
+			wantErr:   false,
+		},
+		{
+			desc:      "multi entry log: last",
+			leaves:    []string{"foo", "bar", "baz"},
+			lookupIdx: 2,
+			wantErr:   false,
+		}, {
+			desc:      "multi entry log: penultimate",
+			leaves:    []string{"foo", "bar", "baz"},
+			lookupIdx: 1,
+			wantErr:   false,
+		},
+	}
+	for _, tC := range testCases {
+		t.Run(tC.desc, func(t *testing.T) {
+			dir, err := os.MkdirTemp("", "testOutputLog")
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer func() {
+				_ = os.RemoveAll(dir)
+			}()
+
+			log, closer, err := NewOutputLog(t.Context(), dir, s, v)
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer closer()
+
+			for _, l := range tC.leaves {
+				if _, _, err := log.Append(t.Context(), []byte(l)); err != nil {
+					t.Fatal(err)
+				}
+			}
+			rawCp, err := log.Checkpoint(t.Context())
+			if err != nil {
+				t.Fatal(err)
+			}
+			cp, err := log.Parse(rawCp)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			data, incProof, err := log.Lookup(t.Context(), tC.lookupIdx, cp.Size)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			hash := rfc6962.DefaultHasher.HashLeaf(data)
+			incProof2 := make([][]byte, len(incProof))
+			for i := range incProof {
+				incProof2[i] = incProof[i][:]
+			}
+			if err := proof.VerifyInclusion(rfc6962.DefaultHasher, tC.lookupIdx, cp.Size, hash, incProof2, cp.Hash); err != nil {
+				t.Fatal(err)
+			}
+		})
+	}
+}


### PR DESCRIPTION
The client now:
 - Verifies the output log checkpoint
 - Verifies the output leaf via inclusion proof in the output log
 - Obtains the vindex root hash and hashes the vindex leaf

The missing part is to generate the inclusion proof in the vindex on
Lookup on the server, and then to verify this on the client.

Once this is done, the remaining client work is to support a flag to
actually dereference all pointers into the input log after the last seen
size. This then forms the basis of a re-runnable self-hosted monitor.
