### PR TITLE
Witness support on SumDB proxy

### DIFF
--- a/sumdb/cmd/proxy.go
+++ b/sumdb/cmd/proxy.go
@@ -26,19 +26,18 @@ import (
 )
 
 var (
-	listen = flag.String("listen", ":8089", "Address to set up HTTP server listening on")
-)
-
-const (
-	upstreamBase = "https://sum.golang.org"
+	listen      = flag.String("listen", ":8089", "Address to set up HTTP server listening on")
+	witnessSigs = flag.Uint("witnesses", 0, "Number of witness signatures required on a checkpoint. Setting this will pull checkpoints from the transparency-dev prod distributor.")
 )
 
 func main() {
 	klog.InitFlags(nil)
 	flag.Parse()
 
-	proxy := sumdb.NewProxy(sumdb.ProxyOpts{})
-	klog.Infof("Proxying tlog-tiles API to %s on %s", upstreamBase, *listen)
+	proxy := sumdb.NewProxy(sumdb.ProxyOpts{
+		WitnessSigs: *witnessSigs,
+	})
+	klog.Infof("tlog-tiles API listening on %s", *listen)
 	if err := http.ListenAndServe(*listen, proxy); err != nil {
 		klog.Fatalf("ListenAndServe: %v", err)
 	}

--- a/vindex/cmd/sumdb/main.go
+++ b/vindex/cmd/sumdb/main.go
@@ -47,6 +47,7 @@ var (
 	outputLogPrivKeyFile = flag.String("output_log_private_key_path", "", "Location of private key file. If unset, uses the contents of the OUTPUT_LOG_PRIVATE_KEY environment variable.")
 	storageDir           = flag.String("storage_dir", "", "Root directory in which to store the data for the demo. This will create subdirectories for the Output Log, and allocate space to store the verifiable map persistence.")
 	persistIndex         = flag.Bool("persist_index", false, "Set to true to use a disk-based implementation of the verifiable index. This can be slow, but useful in situations where memory is constrained.")
+	witnessSigs          = flag.Uint("witnesses", 0, "Number of witness signatures required on the SumDB checkpoint. Setting this will pull checkpoints from the transparency-dev prod distributor.")
 	listen               = flag.String("listen", ":8088", "Address to set up HTTP server listening on")
 )
 
@@ -106,7 +107,8 @@ func run(ctx context.Context) error {
 		return err
 	}
 	sumProxy := sumdb.NewProxy(sumdb.ProxyOpts{
-		PathPrefix: "/inputlog/",
+		PathPrefix:  "/inputlog/",
+		WitnessSigs: *witnessSigs,
 	})
 
 	outputLog, outputCloser := outputLogOrDie(ctx, outputLogDir)


### PR DESCRIPTION
Binaries now support a flag specifiying the number of witness sigs required to be served on the checkpoint. This is implemented as an option on the library.

This will allow developers to test out witnessing support in client tooling, before sumdb supports it natively.
