### PR TITLE
[VIndex] Improve docs on returning leaves

### DIFF
--- a/vindex/map.go
+++ b/vindex/map.go
@@ -69,7 +69,7 @@ type InputLog interface {
 	// Parse unmarshals and verifies a checkpoint obtained from GetCheckpoint.
 	Parse(checkpoint []byte) (*log.Checkpoint, error)
 	// Leaves returns all the leaves in the range [start, end), outputting them via
-	// the returned iterator. The returned bytes MUST be the leaf preimages,
+	// the returned iterator. The yielded bytes MUST be the leaf preimages,
 	// i.e. hashing these values should return the leaf hashes used to construct the
 	// Merkle tree.
 	Leaves(ctx context.Context, start, end uint64) iter.Seq2[[]byte, error]


### PR DESCRIPTION
This is particularly important in CT where the leaves require some modification to match the expected preimage.