### PR TITLE
[VIndex] Support context cancel during indexing

### DIFF
--- a/vindex/map.go
+++ b/vindex/map.go
@@ -558,6 +558,11 @@ func (b *VerifiableIndex) buildMap(ctx context.Context, updateIndex bool) error 
 		b.indexMu.Lock()
 		defer b.indexMu.Unlock()
 		for h := range updatedKeys {
+			select {
+			case <-ctx.Done():
+				return ctx.Err()
+			default:
+			}
 			idxes := b.data[h]
 
 			// Here we hash by simply appending all indices in the list and hashing that


### PR DESCRIPTION
Context cancellation wasn't checked when inserting keys into the index. This was a bug, and becomes particularly problematic when building large in-memory indexes. The process gets slower and slower until it OOMs, and it's hard to kill.
